### PR TITLE
fix: handle plain string AttributeValue when extracting id_token from LogoutRequest

### DIFF
--- a/lib/logout.ts
+++ b/lib/logout.ts
@@ -155,7 +155,8 @@ const parseLogoutRequest = async (rawRequest: string): Promise<ParsedLogoutReque
           try {
             const idTokenElement = extensions[0]?.Attribute?.[0];
             if (idTokenElement && idTokenElement.$ && idTokenElement.$.Name === 'id_token') {
-              idToken = idTokenElement.AttributeValue[0]._;
+              const attrVal = idTokenElement.AttributeValue[0];
+              idToken = typeof attrVal === 'string' ? attrVal : attrVal._;
             }
           } catch {
             // Extensions parsing is best-effort


### PR DESCRIPTION


The xml2js parser returns a plain string when an XML element has no attributes, but an object with a `._` property when it does. The id_token extraction only handled the object case, causing `undefined` when the AttributeValue had no XML attributes.

Apply the same typeof check already used for issuer, nameId, and x509Cert extraction in the same file.